### PR TITLE
Implement request-based room joining with authentication tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,13 @@ Hang is a real-time communication platform built with:
 # Development
 just dev
 
-# Build & Deploy
+# Builds the
 just build
-just deploy live
 
-# Code Quality
+# Runs tsc, linters, and formatters on all packages.
 just check
+
+# Automatically applies linter/formatter suggestions on all packages.
 just fix
 ```
 

--- a/api/server/src/avatar.ts
+++ b/api/server/src/avatar.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { z } from "zod/mini";
 import * as Account from "./account";
+import * as Auth from "./auth";
 import * as rpc from "./rpc";
 
 export { randomAvatar as random } from "./client";
@@ -31,7 +32,7 @@ export const router = rpc
 				file: z.instanceof(File),
 			}),
 		),
-		rpc.withAccount,
+		Auth.required,
 		async (c) => {
 			const ctx = c.var.ctx;
 			const file = c.req.valid("form").file;

--- a/api/server/src/index.ts
+++ b/api/server/src/index.ts
@@ -2,15 +2,17 @@ import * as Account from "./account";
 import * as Avatar from "./avatar";
 import * as Health from "./health";
 import * as OAuth from "./oauth";
+import * as Room from "./room";
 import * as rpc from "./rpc";
 
-export { Account, Avatar, Health, OAuth };
+export { Account, Avatar, Health, OAuth, Room };
 
 const app = rpc
 	.app()
 	.route("/auth", OAuth.router)
 	.route("/avatar", Avatar.router)
 	.route("/account", Account.router)
+	.route("/room", Room.router)
 	.route("/health", Health.router);
 
 export type App = typeof app;

--- a/api/server/src/oauth.ts
+++ b/api/server/src/oauth.ts
@@ -347,7 +347,7 @@ export const router = rpc
 			await provider.link(user.id, oauthUser.providerId);
 
 			// Generate JWT token
-			const token = await ctx.jwt.create(user.id);
+			const token = await ctx.auth.create(user.id);
 			const state = c.req.valid("query").state;
 
 			// Redirect to frontend with token

--- a/api/server/src/room.ts
+++ b/api/server/src/room.ts
@@ -26,7 +26,7 @@ export class Context {
 			return new URL(root, this.#env.RELAY_URL);
 		}
 
-		const token = await Token.sign(this.#key, { root, subscribe: "", publish: `${account}/` });
+		const token = await Token.sign(this.#key, { path: root, sub: "", pub: `${account}/` });
 		return new URL(`${root}?jwt=${token}`, this.#env.RELAY_URL);
 	}
 }

--- a/app/src/sup.tsx
+++ b/app/src/sup.tsx
@@ -65,10 +65,37 @@ export function Sup(props: { canvas: Canvas; api: Api.Client; room: string }): J
 }
 
 function App(props: { canvas: Canvas; room: string; api: Api.Client; info: Info }): JSX.Element {
-	const url = new URL(`${import.meta.env.VITE_RELAY_URL}/hang/${props.room}/`);
+	const [room, setRoom] = createSignal<Room | undefined>(undefined);
+	const [error, setError] = createSignal<string | undefined>(undefined);
 
-	const room = new Room(url, props.canvas, { user: props.info.name, avatar: props.info.avatar });
-	onCleanup(() => room.close());
+	onMount(async () => {
+		try {
+			// Request join URL/token from the API server
+			const response = await props.api.routes.room[":name"].join.$post({
+				param: { name: props.room },
+			});
+
+			if (!response.ok) {
+				throw new Error(`Failed to get join URL: ${response.statusText}`);
+			}
+
+			const { url } = await response.json();
+			const roomInstance = new Room(new URL(url), props.canvas, {
+				user: props.info.name,
+				avatar: props.info.avatar,
+			});
+			setRoom(roomInstance);
+		} catch (e) {
+			setError(`Failed to join room: ${e}`);
+		}
+	});
+
+	onCleanup(() => {
+		const roomInstance = room();
+		if (roomInstance) {
+			roomInstance.close();
+		}
+	});
 
 	/*
 	if (props.api.authenticated()) {
@@ -87,10 +114,45 @@ function App(props: { canvas: Canvas; room: string; api: Api.Client; info: Info 
 	*/
 
 	return (
-		<Layout full={true} connection={room.connection}>
-			<Chat canvas={props.canvas} room={room} />
-			<Controls room={room} camera={room.camera} screen={room.screen} canvas={props.canvas} />
-		</Layout>
+		<Show
+			when={error()}
+			fallback={
+				<Show
+					when={room()}
+					fallback={
+						<Layout full={true}>
+							<div class="flex items-center justify-center h-full">
+								<div class="text-center">
+									<div class="text-lg font-semibold mb-2">Joining room...</div>
+									<div class="text-gray-400">Getting access token</div>
+								</div>
+							</div>
+						</Layout>
+					}
+				>
+					{(roomInstance) => (
+						<Layout full={true} connection={roomInstance().connection}>
+							<Chat canvas={props.canvas} room={roomInstance()} />
+							<Controls
+								room={roomInstance()}
+								camera={roomInstance().camera}
+								screen={roomInstance().screen}
+								canvas={props.canvas}
+							/>
+						</Layout>
+					)}
+				</Show>
+			}
+		>
+			<Layout full={true}>
+				<div class="flex items-center justify-center h-full">
+					<div class="bg-red-500/20 border border-red-400/30 rounded-2xl p-6 text-red-300 text-center max-w-md">
+						<div class="text-lg font-semibold mb-2">Failed to join room</div>
+						<div class="text-sm">{error()}</div>
+					</div>
+				</div>
+			</Layout>
+		</Show>
 	);
 }
 


### PR DESCRIPTION
## Summary
- Adds new `/room/:name/join` API endpoint that generates authenticated room URLs
- Updates frontend to request join URL from API server instead of constructing URLs directly
- Implements proper authentication flow for room access with fallback to anonymous users
- Adds comprehensive error handling and loading states for room connections
- Updates auth middleware usage across avatar and OAuth routes

## Changes
- **Backend**: New room router with join endpoint supporting authenticated and anonymous access
- **Frontend**: Async room initialization with proper error boundaries and loading states
- **Auth**: Consistent use of `Auth.required` middleware and `ctx.auth.create` for token generation
- **Documentation**: Updated CLAUDE.md with clearer command descriptions

## Test plan
- [ ] Verify authenticated users can join rooms with proper tokens
- [ ] Verify anonymous users can join rooms with generated IDs
- [ ] Test error handling for failed room joins
- [ ] Confirm loading states display correctly during room connection
- [ ] Validate token format compatibility with MOQ library

🤖 Generated with [Claude Code](https://claude.ai/code)